### PR TITLE
Upgrade to 1.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17
-yarn_mappings=1.17+build.5
-loader_version=0.11.3
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.22
+loader_version=0.12.12
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.1.0
 maven_group=link.infra.tinymap
 archives_base_name=tinymap
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.34.9+1.17
+fabric_version=0.46.2+1.18

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/link/infra/tinymap/BlockDigger.java
+++ b/src/main/java/link/infra/tinymap/BlockDigger.java
@@ -1,19 +1,32 @@
 package link.infra.tinymap;
 
+import com.mojang.serialization.Codec;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import link.infra.tinymap.mixin.MinecraftServerAccessor;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.registry.BuiltinRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.ChunkSerializer;
 import net.minecraft.world.Heightmap;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkSection;
+import net.minecraft.world.chunk.PalettedContainer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,8 +43,19 @@ class BlockDigger {
 	private final ServerWorld world;
 	private final ThreadedAnvilChunkStorage tacs;
 
+	private static final Codec<PalettedContainer<BlockState>> CODEC = PalettedContainer.createCodec(Block.STATE_IDS, BlockState.CODEC, PalettedContainer.PaletteProvider.BLOCK_STATE, Blocks.AIR.getDefaultState());
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	private static Codec<PalettedContainer<Biome>> createCodec(Registry<Biome> biomeRegistry) {
+		return PalettedContainer.createCodec(biomeRegistry, biomeRegistry.getCodec(), PalettedContainer.PaletteProvider.BIOME, biomeRegistry.getOrThrow(BiomeKeys.PLAINS));
+	}
+
+	private static void logRecoverableError(ChunkPos chunkPos, int y, String message) {
+		LOGGER.error("Recoverable errors when loading section [" + chunkPos.x + ", " + y + ", " + chunkPos.z + "]: " + message);
+	}
+
 	public BlockDigger(MinecraftServer server, ServerWorld world) {
-		regionFolder = new File(((MinecraftServerAccessor) server).getSession().getWorldDirectory(world.getRegistryKey()), "region");
+		regionFolder = new File(((MinecraftServerAccessor) server).getSession().getWorldDirectory(world.getRegistryKey()).toFile(), "region");
 		this.world = world;
 		this.tacs = world.getChunkManager().threadedAnvilChunkStorage;
 	}
@@ -135,23 +159,32 @@ class BlockDigger {
 				}
 
 				NbtCompound level = chunkData.getCompound("Level");
-				NbtList sectionList = level.getList("Sections", 10);
-				ChunkSection[] sections = new ChunkSection[16];
+				NbtList sectionList = chunkData.getList("sections", 10);
+
+				int vertical_section_count = world.countVerticalSections();
+
+				ChunkSection[] sections = new ChunkSection[vertical_section_count];
+
+				PalettedContainer<Biome> palettedContainer2;
+				Object palettedContainer;
+				Registry<Biome> registry = world.getRegistryManager().get(Registry.BIOME_KEY);
+				Codec<PalettedContainer<Biome>> codec = createCodec(registry);
 
 				for (int i = 0; i < sectionList.size(); ++i) {
 					NbtCompound sectionTag = sectionList.getCompound(i);
 					int y = sectionTag.getByte("Y");
-					if (sectionTag.contains("Palette", 9) && sectionTag.contains("BlockStates", 12)) {
-						ChunkSection section = new ChunkSection(y << 4);
-						section.getBlockStateContainer().read(sectionTag.getList("Palette", 10), sectionTag.getLongArray("BlockStates"));
-						section.calculateCounts();
-						if (!section.isEmpty()) {
-							sections[y] = section;
-						}
+					int l = world.sectionCoordToIndex(y);
+
+					if (l >= 0 && l < sections.length) {
+						palettedContainer = sectionTag.contains("block_states", 10) ? (PalettedContainer)CODEC.parse(NbtOps.INSTANCE, sectionTag.getCompound("block_states")).promotePartial(errorMessage -> logRecoverableError(pos, y, errorMessage)).getOrThrow(false, LOGGER::error) : new PalettedContainer(Block.STATE_IDS, Blocks.AIR.getDefaultState(), PalettedContainer.PaletteProvider.BLOCK_STATE);
+						palettedContainer2 = sectionTag.contains("biomes", 10) ? (PalettedContainer)codec.parse(NbtOps.INSTANCE, sectionTag.getCompound("biomes")).promotePartial(errorMessage -> logRecoverableError(pos, y, errorMessage)).getOrThrow(false, LOGGER::error) : new PalettedContainer<Biome>(registry, registry.getOrThrow(BiomeKeys.PLAINS), PalettedContainer.PaletteProvider.BIOME);
+						ChunkSection chunkSection = new ChunkSection(y, (PalettedContainer<BlockState>)palettedContainer, (PalettedContainer<Biome>)palettedContainer2);
+						chunkSection.calculateCounts();
+						sections[l] = chunkSection;
 					}
 				}
 
-				Chunk unloadedChunkView = new UnloadedChunkView(sections);
+				Chunk unloadedChunkView = new UnloadedChunkView(sections, world, pos);
 
 				NbtCompound heightmaps = level.getCompound("Heightmaps");
 				String heightmapName = Heightmap.Type.WORLD_SURFACE.getName();

--- a/src/main/java/link/infra/tinymap/BlockDigger.java
+++ b/src/main/java/link/infra/tinymap/BlockDigger.java
@@ -143,7 +143,7 @@ class BlockDigger {
 					int y = sectionTag.getByte("Y");
 					if (sectionTag.contains("Palette", 9) && sectionTag.contains("BlockStates", 12)) {
 						ChunkSection section = new ChunkSection(y << 4);
-						section.getContainer().read(sectionTag.getList("Palette", 10), sectionTag.getLongArray("BlockStates"));
+						section.getBlockStateContainer().read(sectionTag.getList("Palette", 10), sectionTag.getLongArray("BlockStates"));
 						section.calculateCounts();
 						if (!section.isEmpty()) {
 							sections[y] = section;

--- a/src/main/java/link/infra/tinymap/TileGenerator.java
+++ b/src/main/java/link/infra/tinymap/TileGenerator.java
@@ -15,6 +15,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 
 import javax.imageio.ImageIO;
+import link.infra.tinymap.BlockDigger.Session;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.awt.image.DirectColorModel;

--- a/src/main/java/link/infra/tinymap/UnloadedChunkView.java
+++ b/src/main/java/link/infra/tinymap/UnloadedChunkView.java
@@ -37,11 +37,13 @@ import java.util.stream.Stream;
 class UnloadedChunkView extends Chunk {
 	private final ChunkSection[] sections;
 	private final World world;
+	private final Heightmap worldSurfaceHeightmap;
 
 	UnloadedChunkView(ChunkSection[] sections, World world, ChunkPos pos) {
 		super(pos, UpgradeData.NO_UPGRADE_DATA, world, world.getRegistryManager().get(Registry.BIOME_KEY), 0, null, null);
 		this.sections = sections;
 		this.world = world;
+		this.worldSurfaceHeightmap = new Heightmap(this, Heightmap.Type.WORLD_SURFACE);
 	}
 
 	@Override
@@ -54,8 +56,12 @@ class UnloadedChunkView extends Chunk {
 		int x = pos.getX();
 		int y = pos.getY();
 		int z = pos.getZ();
-		if (y >= 0 && y >> 4 < this.sections.length) {
-			ChunkSection chunkSection = this.sections[y >> 4];
+
+		int sectionIndex = this.getSectionIndex(y);
+
+		if (sectionIndex >= 0 && sectionIndex < this.sections.length) {
+			ChunkSection chunkSection = this.sections[sectionIndex];
+
 			if (!chunkSection.isEmpty()) {
 				return chunkSection.getBlockState(x & 15, y & 15, z & 15);
 			}
@@ -69,8 +75,12 @@ class UnloadedChunkView extends Chunk {
 		int x = pos.getX();
 		int y = pos.getY();
 		int z = pos.getZ();
-		if (y >= 0 && y >> 4 < this.sections.length) {
-			ChunkSection chunkSection = this.sections[y >> 4];
+
+		int sectionIndex = this.getSectionIndex(y);
+
+		if (sectionIndex >= 0 && sectionIndex < this.sections.length) {
+			ChunkSection chunkSection = this.sections[sectionIndex];
+
 			if (!chunkSection.isEmpty()) {
 				return chunkSection.getFluidState(x & 15, y & 15, z & 15);
 			}
@@ -97,11 +107,8 @@ class UnloadedChunkView extends Chunk {
 
 	@Override
 	public ChunkSection[] getSectionArray() {
-		System.out.println("Returning SectionArray: " + sections);
 		return sections;
 	}
-
-	private final Heightmap worldSurfaceHeightmap = new Heightmap(this, Heightmap.Type.WORLD_SURFACE);
 
 	@Override
 	public Collection<Map.Entry<Heightmap.Type, Heightmap>> getHeightmaps() {
@@ -265,11 +272,11 @@ class UnloadedChunkView extends Chunk {
 
 	@Override
 	public int getHeight() {
-		return 256;
+		return this.world.getHeight();
 	}
 
 	@Override
 	public int getBottomY() {
-		return 0;
+		return this.world.getBottomY();
 	}
 }

--- a/src/main/java/link/infra/tinymap/UnloadedChunkView.java
+++ b/src/main/java/link/infra/tinymap/UnloadedChunkView.java
@@ -14,14 +14,15 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.structure.StructureStart;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.Heightmap;
-import net.minecraft.world.TickScheduler;
-import net.minecraft.world.biome.source.BiomeArray;
+import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkSection;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.UpgradeData;
 import net.minecraft.world.gen.feature.StructureFeature;
+import net.minecraft.world.tick.BasicTickScheduler;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -33,11 +34,14 @@ import java.util.stream.Stream;
 /**
  * Skeleton implementation of Chunk to represent an unloaded chunk view
  */
-class UnloadedChunkView implements Chunk {
+class UnloadedChunkView extends Chunk {
 	private final ChunkSection[] sections;
+	private final World world;
 
-	UnloadedChunkView(ChunkSection[] sections) {
+	UnloadedChunkView(ChunkSection[] sections, World world, ChunkPos pos) {
+		super(pos, UpgradeData.NO_UPGRADE_DATA, world, world.getRegistryManager().get(Registry.BIOME_KEY), 0, null, null);
 		this.sections = sections;
+		this.world = world;
 	}
 
 	@Override
@@ -52,7 +56,7 @@ class UnloadedChunkView implements Chunk {
 		int z = pos.getZ();
 		if (y >= 0 && y >> 4 < this.sections.length) {
 			ChunkSection chunkSection = this.sections[y >> 4];
-			if (!ChunkSection.isEmpty(chunkSection)) {
+			if (!chunkSection.isEmpty()) {
 				return chunkSection.getBlockState(x & 15, y & 15, z & 15);
 			}
 		}
@@ -67,7 +71,7 @@ class UnloadedChunkView implements Chunk {
 		int z = pos.getZ();
 		if (y >= 0 && y >> 4 < this.sections.length) {
 			ChunkSection chunkSection = this.sections[y >> 4];
-			if (!ChunkSection.isEmpty(chunkSection)) {
+			if (!chunkSection.isEmpty()) {
 				return chunkSection.getFluidState(x & 15, y & 15, z & 15);
 			}
 		}
@@ -93,6 +97,7 @@ class UnloadedChunkView implements Chunk {
 
 	@Override
 	public ChunkSection[] getSectionArray() {
+		System.out.println("Returning SectionArray: " + sections);
 		return sections;
 	}
 
@@ -134,11 +139,6 @@ class UnloadedChunkView implements Chunk {
 	}
 
 	@Override
-	public BlockPos method_35319(Heightmap.Type type) {
-		return null;
-	}
-
-	@Override
 	public ChunkPos getPos() {
 		return null;
 	}
@@ -151,11 +151,6 @@ class UnloadedChunkView implements Chunk {
 	@Override
 	public void setStructureStarts(Map<StructureFeature<?>, StructureStart<?>> structureStarts) {
 
-	}
-
-	@Override
-	public @Nullable BiomeArray getBiomeArray() {
-		return null;
 	}
 
 	@Override
@@ -199,12 +194,17 @@ class UnloadedChunkView implements Chunk {
 	}
 
 	@Override
-	public TickScheduler<Block> getBlockTickScheduler() {
+	public BasicTickScheduler<Block> getBlockTickScheduler() {
 		return null;
 	}
 
 	@Override
-	public TickScheduler<Fluid> getFluidTickScheduler() {
+	public BasicTickScheduler<Fluid> getFluidTickScheduler() {
+		return null;
+	}
+
+	@Override
+	public TickSchedulers getTickSchedulers() {
 		return null;
 	}
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
 	"depends": {
 		"fabricloader": ">=0.11.3",
 		"fabric": "*",
-		"minecraft": "1.17.x",
+		"minecraft": "1.18.x",
 		"java": ">=16"
 	},
 	"mixins": [


### PR DESCRIPTION
I needed to get unloaded chunk data for something, and I thought I'd use your `BlockDigger` and `UnloadedChunkView` classes for that. (The idea is to implement them in a separate library, FYI)

But I had to get it working in 1.18 first, of course :)
So here's that! As you can see, rendering loaded & unloaded chunks works fine:

![image](https://user-images.githubusercontent.com/755212/150635746-41c97e60-fe49-4865-83e1-59dbd437edd9.png)

I'm not sure what the white & gray tiles represent (I guess non-generated chunks in an existing region?)

I also think  worlds that have not fully upgraded to 1.18 might cause a problem. Tinymap will try to load those unloaded chunks in, expecting the 1.18 format but finding something different. I might take a stab at that later though.

